### PR TITLE
Make puzzle name/answers unselectable

### DIFF
--- a/packages/site/src/components/css/puzzles.css
+++ b/packages/site/src/components/css/puzzles.css
@@ -59,6 +59,12 @@ fast-dialog {
 	padding: var(--card-padding);
 }
 
+.unselectable {
+	-webkit-user-select: none; /* Safari */
+	-ms-user-select: none; /* IE 10+ */
+	user-select: none;
+}
+
 @media screen and (max-width: 1200px) {
 	#libralogo {
 		visibility: hidden;

--- a/packages/site/src/components/puzzles/puzzles.tsx
+++ b/packages/site/src/components/puzzles/puzzles.tsx
@@ -421,7 +421,7 @@ const PuzzleObjCommonListItems: React.FC<{
 	return (
 		<>
 			<div className="puzzle-or-round-info" />
-			<p>{name}</p>
+			<p className="unselectable">{name}</p>
 			<Anchor href={url} target="_blank">
 				{type === 'puzzle' ? 'Puzzle' : 'Round'} Link
 			</Anchor>
@@ -456,7 +456,9 @@ const PuzzleListItems: React.FC<{
 					Spreadsheet
 				</Anchor>
 			)}
-			{puzzleObj.answer && <p>Answer: {puzzleObj.answer}</p>}
+			{puzzleObj.answer && (
+				<p className="unselectable">Answer: {puzzleObj.answer}</p>
+			)}
 			{puzzleObj.status &&
 				puzzleObj.lastStatusUpdate &&
 				!puzzleObj.answer && (


### PR DESCRIPTION
This is an attempt to get the editing UI to work more nicely on iOS. Right now the OS intercepts the context click event to select text (as the hit is in the margin).

This issue is a bit hard to debug, since the chrome emulator doesn't match the behavior on a real device.