### PR TITLE
Implement a number of mystery hunt 2024 suggestions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,10 @@ jobs:
 
             - name: Run tests
               run: npm run test
+
+            - name: Deploy commands to production
+              run: pnpm run --filter=@belle-puzzles/bot update-commands:prod
+              env:
+                  DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+                  CLIENT_ID: ${{ secrets.CLIENT_ID }}
+              if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -69,7 +69,11 @@
 			"request": "launch",
 			"name": "Serverless: Debug Current Test File (bot)",
 			"autoAttachChildProcesses": true,
-			"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+			"skipFiles": [
+				"<node_internals>/**",
+				// Disable this to debug in FF or discord.js code.
+				"**/node_modules/**"
+			],
 			"program": "${workspaceRoot}/packages/bot/node_modules/vitest/vitest.mjs",
 			"cwd": "${workspaceRoot}/packages/bot",
 			"args": ["run", "${relativeFile}"],

--- a/packages/bot/src/commands/add-puzzle.ts
+++ b/packages/bot/src/commands/add-puzzle.ts
@@ -25,7 +25,7 @@ export const addPuzzle: Command = {
 				.setName(URL_ARG)
 				.setRequired(true)
 		)
-		.addStringOption((builder) =>
+		.addChannelOption((builder) =>
 			builder
 				.setDescription("Parent round's index channel")
 				.setName(ROUND_ARG)

--- a/packages/bot/src/commands/add-round.ts
+++ b/packages/bot/src/commands/add-round.ts
@@ -25,7 +25,7 @@ export const addRound: Command = {
 				.setName(URL_ARG)
 				.setRequired(true)
 		)
-		.addStringOption((builder) =>
+		.addChannelOption((builder) =>
 			builder
 				.setDescription("Parent round's index channel")
 				.setName(ROUND_ARG)

--- a/packages/bot/src/commands/edit.ts
+++ b/packages/bot/src/commands/edit.ts
@@ -1,0 +1,104 @@
+import {
+	CacheType,
+	ChatInputCommandInteraction,
+	SlashCommandBuilder,
+} from 'discord.js';
+import { Command } from './types';
+import { PuzzlehuntContext } from '../puzzlehunt-context';
+import { computeAssociatedRoundOrPuzzle } from '../utils/index.js';
+
+const NAME_ARG = 'new_name';
+const URL_ARG = 'new_url';
+const SHEET_ID_ARG = 'new_sheet_id';
+
+export const edit: Command = {
+	data: new SlashCommandBuilder()
+		.setName('edit')
+		.addSubcommand((builder) =>
+			builder
+				.setName('name')
+				.setDescription('Change the name of a puzzle or round')
+				.addStringOption((builder) =>
+					builder
+						.setName(NAME_ARG)
+						.setDescription('New name')
+						.setMinLength(1)
+						.setRequired(true)
+				)
+		)
+		.addSubcommand((builder) =>
+			builder
+				.setName('url')
+				.setDescription('Change the URL of a puzzle or round')
+				.addStringOption((builder) =>
+					builder
+						.setName(URL_ARG)
+						.setDescription('New URL')
+						.setMinLength(1)
+						.setRequired(true)
+				)
+		)
+		.addSubcommand((builder) =>
+			builder
+				.setName('sheet_id')
+				.setDescription(
+					'Change the Google Sheet ID associated with a puzzle.'
+				)
+				.addStringOption((builder) =>
+					builder
+						.setName(SHEET_ID_ARG)
+						.setDescription('New Google Sheet ID')
+						.setMinLength(1)
+						.setRequired(true)
+				)
+		),
+	async execute(
+		{ puzzlehunt }: PuzzlehuntContext,
+		interaction: ChatInputCommandInteraction<CacheType>
+	) {
+		if (!interaction.deferred) {
+			await interaction.deferReply({ ephemeral: true });
+		}
+
+		const puzzleObj = await computeAssociatedRoundOrPuzzle(
+			interaction.channel,
+			puzzlehunt
+		);
+		if (!puzzleObj) {
+			await interaction.editReply(
+				'This command must be run from a puzzle or round channel.'
+			);
+			return;
+		}
+
+		const subcommand = interaction.options.getSubcommand();
+		switch (subcommand) {
+			case 'name':
+				const newName = interaction.options.getString(NAME_ARG);
+				puzzlehunt.changeName(puzzleObj, newName);
+				break;
+			case 'url':
+				const newUrl = interaction.options.getString(URL_ARG);
+				try {
+					new URL(newUrl);
+				} catch (err) {
+					await interaction.editReply('Invalid URL.');
+					return;
+				}
+				puzzlehunt.changeUrl(puzzleObj, newUrl);
+				break;
+			case 'sheet_id':
+				if (puzzleObj.type !== 'puzzle') {
+					await interaction.editReply(
+						'This command can only be run from a puzzle channel.'
+					);
+					return;
+				}
+				const newSheetId = interaction.options.getString(SHEET_ID_ARG);
+				puzzlehunt.augmentWithGoogleSheet(puzzleObj, newSheetId);
+				break;
+		}
+
+		await interaction.editReply('Updated.');
+	},
+};

--- a/packages/bot/src/commands/index.ts
+++ b/packages/bot/src/commands/index.ts
@@ -3,6 +3,7 @@ export * from './unsolve.js';
 export * from './create.js';
 export * from './add-puzzle.js';
 export * from './add-round.js';
+export * from './edit.js';
 export * from './resync-all.js';
 export * from './reset-server.js';
 export * from './change-backing-fluid-file.js';

--- a/packages/bot/src/commands/types.ts
+++ b/packages/bot/src/commands/types.ts
@@ -1,12 +1,13 @@
 import type {
 	SlashCommandBuilder,
 	ChatInputCommandInteraction,
+	SlashCommandSubcommandsOnlyBuilder,
 } from 'discord.js';
 import type { PuzzlehuntContext } from '../puzzlehunt-context';
 
 export interface Command {
 	requiresSerializedContext?: boolean; // defaults to true
-	data: SlashCommandBuilder;
+	data: SlashCommandBuilder | SlashCommandSubcommandsOnlyBuilder;
 	testServerOnly?: boolean; // defaults to false
 	adminOnly?: boolean; // defaults to false
 	execute: (

--- a/packages/bot/src/puzzlehunt-context.ts
+++ b/packages/bot/src/puzzlehunt-context.ts
@@ -64,9 +64,9 @@ export async function getHuntContext(
 				async (task, callback) => {
 					try {
 						await task();
-						callback();
+						callback?.();
 					} catch (error) {
-						callback(error);
+						callback?.(error);
 					}
 				},
 				1

--- a/packages/bot/src/test/commands/add-puzzle.spec.ts
+++ b/packages/bot/src/test/commands/add-puzzle.spec.ts
@@ -1,12 +1,4 @@
-import {
-	describe,
-	it,
-	beforeAll,
-	beforeEach,
-	afterEach,
-	expect,
-	vi,
-} from 'vitest';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 import { BelleBotClient, createClient } from '../../client';
 import {
 	IPuzzlehuntProvider,
@@ -196,11 +188,7 @@ describe('add_puzzle', () => {
 	});
 
 	describe('reports a reasonable error', () => {
-		// None of these commands should modify the state of the discord server or the puzzlehunt, so
-		// a single `before` is sufficient.
-		// If debugging a failure in one of these tests and that assumption isn't valid, might be better
-		// to change this to beforeEach temporarly.
-		beforeAll(initializePuzzlehunt);
+		beforeEach(initializePuzzlehunt);
 
 		it('when run without a parent round in an invalid channel', async () => {
 			const adminChannel = serverState.findChannelBy(
@@ -217,30 +205,6 @@ describe('add_puzzle', () => {
 
 			expect(interaction.editReply).toHaveBeenCalledWith(
 				'Either run this command from a puzzle channel (to create a sibling puzzle) or specify the parent_round argument.'
-			);
-		});
-
-		it('when run with a non-conformant parent round argument', async () => {
-			const interaction = await runCommand(
-				'/add_puzzle name: puzzle 1 url: mock-puzzle-url parent_round: 1234',
-				client,
-				mockDiscord
-			);
-
-			expect(interaction.editReply).toHaveBeenCalledWith(
-				'parent_round should be a discord channel.'
-			);
-		});
-
-		it('when run with a parent round argument pointing to an invalid channel', async () => {
-			const interaction = await runCommand(
-				'/add_puzzle name: puzzle 1 url: mock-puzzle-url parent_round: <#1234>',
-				client,
-				mockDiscord
-			);
-
-			expect(interaction.editReply).toHaveBeenCalledWith(
-				'parent_round should be one of the round index channels.'
 			);
 		});
 	});

--- a/packages/bot/src/test/commands/edit.spec.ts
+++ b/packages/bot/src/test/commands/edit.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { BelleBotClient, createClient } from '../../client';
+import {
+	IPuzzlehuntProvider,
+	createPuzzlehuntProvider,
+} from '../../puzzlehunt-provider';
+import { ChannelData, IServerState, MockDiscord } from '../mockDiscord';
+import { loadPuzzlehunt, runCommand, runCommands } from '../testUtils';
+vi.mock('../../integrations/google.js');
+
+describe('edit', () => {
+	const asyncErrors: any[] = [];
+	const getPuzzlehunt = () => loadPuzzlehunt(puzzlehuntProvider, mockDiscord);
+	let puzzlehuntProvider: IPuzzlehuntProvider;
+	let mockDiscord: MockDiscord;
+	let serverState: IServerState;
+	let client: BelleBotClient;
+	let puzzleChannel: ChannelData;
+
+	const initializePuzzlehunt = async () => {
+		puzzlehuntProvider = createPuzzlehuntProvider();
+		mockDiscord = new MockDiscord();
+		serverState = mockDiscord.serverState;
+		client = createClient({
+			token: 'mock-token',
+			puzzlehuntProvider,
+			baseClient: mockDiscord.getClient(),
+			onError: async (error) => {
+				asyncErrors.push({ error, stack: error.stack });
+			},
+		});
+		await runCommands(client, mockDiscord, [
+			'/create name: test-hunt folder_link: https://drive.google.com/drive/folders/mock-folder-id?usp=sharing',
+			'/add_round name: round 1 url: mock-url',
+		]);
+		const round1IndexId = serverState.findChannelBy(
+			'name',
+			'round-1-puzzles'
+		)?.id;
+		expect(round1IndexId).toBeDefined();
+		await runCommand(
+			`/add_puzzle name: puzzle 1 url: mock-puzzle-url parent_round: <#${round1IndexId}>`,
+			client,
+			mockDiscord
+		);
+		puzzleChannel = serverState.findChannelBy('name', 'puzzle-1');
+	};
+
+	beforeEach(initializePuzzlehunt);
+
+	afterEach(() => {
+		vi.resetAllMocks();
+		expect(asyncErrors).toEqual([]);
+		asyncErrors.length = 0;
+	});
+
+	describe('supports editing name', () => {
+		it('of a puzzle', async () => {
+			const interaction = await runCommand(
+				'/edit name new_name: new name',
+				client,
+				mockDiscord,
+				puzzleChannel
+			);
+			expect(interaction.editReply).toHaveBeenCalledWith('Updated.');
+			const puzzlehunt = await getPuzzlehunt();
+			const puzzle = Array.from(puzzlehunt.puzzles)[0];
+			expect(puzzle.name).toEqual('new name');
+		});
+
+		it('of a round', async () => {
+			const interaction = await runCommand(
+				'/edit name new_name: new name',
+				client,
+				mockDiscord,
+				serverState.findChannelBy('name', 'round-1-puzzles')
+			);
+			expect(interaction.editReply).toHaveBeenCalledWith('Updated.');
+			const puzzlehunt = await getPuzzlehunt();
+			const round = Array.from(puzzlehunt.rounds)[0];
+			expect(round.name).toEqual('new name');
+		});
+	});
+
+	describe('supports editing URL', () => {
+		it('of a puzzle', async () => {
+			const interaction = await runCommand(
+				'/edit url new_url: https://google.com',
+				client,
+				mockDiscord,
+				puzzleChannel
+			);
+			expect(interaction.editReply).toHaveBeenCalledWith('Updated.');
+			const puzzlehunt = await getPuzzlehunt();
+			const puzzle = Array.from(puzzlehunt.puzzles)[0];
+			expect(puzzle.url).toEqual('https://google.com');
+		});
+
+		it('of a round', async () => {
+			const interaction = await runCommand(
+				'/edit url new_url: https://google.com',
+				client,
+				mockDiscord,
+				serverState.findChannelBy('name', 'round-1-puzzles')
+			);
+			expect(interaction.editReply).toHaveBeenCalledWith('Updated.');
+			const puzzlehunt = await getPuzzlehunt();
+			const round = Array.from(puzzlehunt.rounds)[0];
+			expect(round.url).toEqual('https://google.com');
+		});
+	});
+
+	describe('supports editing sheet ID', () => {
+		it('of a puzzle', async () => {
+			const interaction = await runCommand(
+				'/edit sheet_id new_sheet_id: mock-sheet-id-2',
+				client,
+				mockDiscord,
+				puzzleChannel
+			);
+			expect(interaction.editReply).toHaveBeenCalledWith('Updated.');
+			const puzzlehunt = await getPuzzlehunt();
+			const puzzle = Array.from(puzzlehunt.puzzles)[0];
+			expect(puzzle.sheetId).toEqual('mock-sheet-id-2');
+		});
+	});
+});

--- a/packages/bot/src/utils/index.ts
+++ b/packages/bot/src/utils/index.ts
@@ -171,16 +171,9 @@ export async function computeParentRound(
 		puzzlehunt
 	);
 	let parentRound: Round;
-	const parentRoundArg = interaction.options.getString(ROUND_ARG);
+	const parentRoundArg = interaction.options.getChannel(ROUND_ARG);
 	if (parentRoundArg) {
-		const match = parentRoundArg.match(/^<#(\d*)>$/);
-		if (!match) {
-			await interaction.editReply(
-				'parent_round should be a discord channel.'
-			);
-			return { valid: false };
-		}
-		const [, indexChannelId] = match;
+		const indexChannelId = parentRoundArg.id;
 		parentRound = Array.from(puzzlehunt.rounds).find(
 			(round) => round.discordInfo?.indexChannelId === indexChannelId
 		);

--- a/packages/puzzlehunt-model/src/puzzlehunt.ts
+++ b/packages/puzzlehunt-model/src/puzzlehunt.ts
@@ -136,6 +136,7 @@ export interface IPuzzlehunt extends TypedEventEmitter<IPuzzlehuntEvents> {
 	addPuzzles(puzzles: { name: string; url: string }[], round: Round): void;
 	delete(puzzleObj: Puzzle | Round): void;
 	changeName(puzzleObj: Puzzle | Round, name: string): void;
+	changeUrl(puzzleObj: Puzzle | Round, url: string): void;
 	addRound(name: string, url: string, parentRound?: Round): Round;
 	addRounds(
 		rounds: { name: string; url: string }[],
@@ -616,6 +617,15 @@ class Puzzlehunt
 			...replace(makeString(name), {
 				parent: puzzleObj.id,
 				label: traitLabels.name,
+			})
+		);
+	}
+
+	public changeUrl(puzzleObj: Puzzle | Round, url: string): void {
+		this.checkout.applyEdit(
+			...replace(makeString(url), {
+				parent: puzzleObj.id,
+				label: traitLabels.url,
 			})
 		);
 	}

--- a/packages/site/src/components/about/about.tsx
+++ b/packages/site/src/components/about/about.tsx
@@ -142,10 +142,9 @@ export const About: React.FC = () => {
 				</p>
 				<h2>Permissions</h2>
 				<p>
-					Belle doesn't currently support a permissions model: beware
-					that created google sheets and all puzzlehunts are available
-					to the general public from an information security
-					standpoint.
+					The visibility of all spreadsheets created by Belle will match that of the Google Drive folder used to create the puzzlehunt.
+					If you want to restrict access to the puzzlehunt, you must share that folder with belle-714@belle-puzzles.iam.gserviceaccount.com,
+					which is the Google service account for Belle.
 				</p>
 				<h2>Technical Details</h2>
 				<p>

--- a/packages/site/src/components/puzzles/modals/editNameModal.tsx
+++ b/packages/site/src/components/puzzles/modals/editNameModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Card, Button, Dialog, TextField } from '../../../fast';
 import { IPuzzlehunt, Puzzle, Round } from '@belle-puzzles/puzzlehunt-model';
+import { SingleInputModal } from './singleInputModal';
 
 export interface EditNameModalProps {
 	puzzleObj: Round | Puzzle;
@@ -13,92 +13,24 @@ export const EditNameModal: React.FC<EditNameModalProps> = ({
 	puzzlehunt,
 	close,
 }) => {
-	const [errorText, setErrorText] = React.useState<string | undefined>(
-		undefined
-	);
-	const [content, setContent] = React.useState<string | undefined>(undefined);
-
-	React.useEffect(() => {
-		if (errorText) {
-			setTimeout(() => setErrorText(undefined), 5000);
-		}
-	}, [errorText]);
-	const errorStyles = {
-		border: '2px solid red',
-		borderRadius: '5px',
-	};
-
 	return (
-		<Dialog
-			modal
-			className="modal"
-			style={
-				{
-					'--dialog-width': '480px',
-					'--dialog-height': '320px',
-				} as any /* these are custom properties on fast components */
-			}
-		>
-			<Card
-				style={{ overflow: 'auto' }}
-				/* prevent light-dismiss */
-				onClick={(event) => event.stopPropagation()}
-			>
-				<h1>Change Name</h1>
-				<p>Enter a new name for "{puzzleObj.name}"</p>
-				<TextField
-					required={true}
-					style={{
-						...(!content && errorText ? errorStyles : {}),
-					}}
-					onChange={(event) => {
-						const content = (event.target as any).value;
-						setContent(content);
-					}}
-					placeholder={`new ${puzzleObj.type} name`}
-					{...(content ? { value: content } : {})}
-				/>
-				{errorText && (
-					<p
-						style={{
-							position: 'fixed',
-							bottom: 'calc(var(--card-padding) + 25px)',
-							right: 'var(--card-padding)',
-						}}
-					>
-						{errorText}
-					</p>
-				)}
-				<Button
-					appearance={'neutral'}
-					style={{
-						position: 'fixed',
-						bottom: 'var(--card-padding)',
-						left: 'var(--card-padding)',
-					}}
-					onClick={close}
-				>
-					Cancel
-				</Button>
-				<Button
-					appearance={'accent'}
-					style={{
-						position: 'fixed',
-						bottom: 'var(--card-padding)',
-						right: 'var(--card-padding)',
-					}}
-					onClick={() => {
-						if (!content) {
-							setErrorText('Name must be filled.');
-							return;
-						}
-						puzzlehunt.changeName(puzzleObj, content);
-						close();
-					}}
-				>
-					Change Name
-				</Button>
-			</Card>
-		</Dialog>
+		<SingleInputModal
+			title={'Change Name'}
+			description={`Enter a new name for "${puzzleObj.name}"`}
+			placeholderText={`new ${puzzleObj.type} name`}
+			confirmText={'Change Name'}
+			close={close}
+			processInput={(input) => {
+				if (!input) {
+					return {
+						type: 'error',
+						displayMessage: 'Name must be filled.',
+					};
+				}
+
+				puzzlehunt.changeName(puzzleObj, input);
+				return { type: 'success' };
+			}}
+		/>
 	);
 };

--- a/packages/site/src/components/puzzles/modals/editSheetIdModal.tsx
+++ b/packages/site/src/components/puzzles/modals/editSheetIdModal.tsx
@@ -1,104 +1,36 @@
 import * as React from 'react';
-import { Card, Button, Dialog, TextField } from '../../../fast';
 import { IPuzzlehunt, Puzzle } from '@belle-puzzles/puzzlehunt-model';
+import { SingleInputModal } from './singleInputModal';
 
-export interface EditSheeetIdModalProps {
+export interface EditSheetIdModalProps {
 	puzzleObj: Puzzle;
 	puzzlehunt: IPuzzlehunt;
 	close: () => void;
 }
 
-export const EditSheetIdModal: React.FC<EditSheeetIdModalProps> = ({
+export const EditSheetIdModal: React.FC<EditSheetIdModalProps> = ({
 	puzzleObj,
 	puzzlehunt,
 	close,
 }) => {
-	const [errorText, setErrorText] = React.useState<string | undefined>(
-		undefined
-	);
-	const [content, setContent] = React.useState<string | undefined>(undefined);
-
-	React.useEffect(() => {
-		if (errorText) {
-			setTimeout(() => setErrorText(undefined), 5000);
-		}
-	}, [errorText]);
-	const errorStyles = {
-		border: '2px solid red',
-		borderRadius: '5px',
-	};
-
 	return (
-		<Dialog
-			modal
-			className="modal"
-			style={
-				{
-					'--dialog-width': '480px',
-					'--dialog-height': '320px',
-				} as any /* these are custom properties on fast components */
-			}
-		>
-			<Card
-				style={{ overflow: 'auto' }}
-				/* prevent light-dismiss */
-				onClick={(event) => event.stopPropagation()}
-			>
-				<h1>Change Sheet ID</h1>
-				<p>Enter a new google sheet ID for "{puzzleObj.name}"</p>
-				<TextField
-					required={true}
-					style={{
-						...(!content && errorText ? errorStyles : {}),
-					}}
-					onChange={(event) => {
-						const content = (event.target as any).value;
-						setContent(content);
-					}}
-					placeholder={`new ${puzzleObj.type} sheet ID`}
-					{...(content ? { value: content } : {})}
-				/>
-				{errorText && (
-					<p
-						style={{
-							position: 'fixed',
-							bottom: 'calc(var(--card-padding) + 25px)',
-							right: 'var(--card-padding)',
-						}}
-					>
-						{errorText}
-					</p>
-				)}
-				<Button
-					appearance={'neutral'}
-					style={{
-						position: 'fixed',
-						bottom: 'var(--card-padding)',
-						left: 'var(--card-padding)',
-					}}
-					onClick={close}
-				>
-					Cancel
-				</Button>
-				<Button
-					appearance={'accent'}
-					style={{
-						position: 'fixed',
-						bottom: 'var(--card-padding)',
-						right: 'var(--card-padding)',
-					}}
-					onClick={() => {
-						if (!content) {
-							setErrorText('Sheet ID must be filled.');
-							return;
-						}
-						puzzlehunt.augmentWithGoogleSheet(puzzleObj, content);
-						close();
-					}}
-				>
-					Change Sheet ID
-				</Button>
-			</Card>
-		</Dialog>
+		<SingleInputModal
+			title={'Change Sheet ID'}
+			description={`Enter a new google sheet ID for "${puzzleObj.name}"`}
+			placeholderText={`new ${puzzleObj.type} sheet ID`}
+			confirmText={'Change Sheet ID'}
+			close={close}
+			processInput={(input) => {
+				if (!input) {
+					return {
+						type: 'error',
+						displayMessage: 'Sheet ID must be filled.',
+					};
+				}
+
+				puzzlehunt.augmentWithGoogleSheet(puzzleObj, input);
+				return { type: 'success' };
+			}}
+		/>
 	);
 };

--- a/packages/site/src/components/puzzles/modals/editUrlModal.tsx
+++ b/packages/site/src/components/puzzles/modals/editUrlModal.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { IPuzzlehunt, Puzzle, Round } from '@belle-puzzles/puzzlehunt-model';
+import { SingleInputModal } from './singleInputModal';
+
+export interface EditUrlModalProps {
+	puzzleObj: Puzzle | Round;
+	puzzlehunt: IPuzzlehunt;
+	close: () => void;
+}
+
+export const EditUrlModal: React.FC<EditUrlModalProps> = ({
+	puzzleObj,
+	puzzlehunt,
+	close,
+}) => {
+	return (
+		<SingleInputModal
+			title={`Change ${puzzleObj.type} URL`}
+			description={`Enter a new URL for "${puzzleObj.name}"`}
+			placeholderText={`new ${puzzleObj.type} URL`}
+			confirmText={'Change URL'}
+			close={close}
+			processInput={(input) => {
+				if (!input) {
+					return {
+						type: 'error',
+						displayMessage: 'URL must be non-empty.',
+					};
+				}
+				try {
+					new URL(input);
+				} catch (e) {
+					return {
+						type: 'error',
+						displayMessage: 'URL must be valid.',
+					};
+				}
+				puzzlehunt.changeUrl(puzzleObj, input);
+				return { type: 'success' };
+			}}
+		/>
+	);
+};

--- a/packages/site/src/components/puzzles/modals/index.ts
+++ b/packages/site/src/components/puzzles/modals/index.ts
@@ -1,4 +1,5 @@
 export * from './addModal';
 export * from './deleteModal';
 export * from './editNameModal';
+export * from './editUrlModal';
 export * from './editSheetIdModal';

--- a/packages/site/src/components/puzzles/modals/singleInputModal.tsx
+++ b/packages/site/src/components/puzzles/modals/singleInputModal.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import { Card, Button, Dialog, TextField } from '../../../fast';
+
+export type InputResult =
+	| { type: 'success' }
+	// displayMessage will be propagated to the user.
+	| { type: 'error'; displayMessage: string };
+
+export interface SingleInputModalProps {
+	title: string;
+	description: string;
+	placeholderText: string;
+	confirmText: string;
+	close: () => void;
+	processInput(input: string): InputResult;
+}
+
+export const SingleInputModal: React.FC<SingleInputModalProps> = ({
+	title,
+	description,
+	placeholderText,
+	confirmText,
+	processInput,
+	close,
+}) => {
+	const [errorText, setErrorText] = React.useState<string | undefined>(
+		undefined
+	);
+	const [content, setContent] = React.useState<string | undefined>(undefined);
+
+	React.useEffect(() => {
+		if (errorText) {
+			setTimeout(() => setErrorText(undefined), 5000);
+		}
+	}, [errorText]);
+	const errorStyles = {
+		border: '2px solid red',
+		borderRadius: '5px',
+	};
+
+	return (
+		<Dialog
+			modal
+			className="modal"
+			style={
+				{
+					'--dialog-width': '480px',
+					'--dialog-height': '320px',
+				} as any /* these are custom properties on fast components */
+			}
+		>
+			<Card
+				style={{ overflow: 'auto' }}
+				/* prevent light-dismiss */
+				onClick={(event) => event.stopPropagation()}
+			>
+				<h1>{title}</h1>
+				<p>{description}</p>
+				<TextField
+					required={true}
+					style={{
+						...(!content && errorText ? errorStyles : {}),
+					}}
+					onChange={(event) => {
+						const content = (event.target as any).value;
+						setContent(content);
+					}}
+					placeholder={placeholderText}
+					{...(content ? { value: content } : {})}
+				/>
+				{errorText && (
+					<p
+						style={{
+							position: 'fixed',
+							bottom: 'calc(var(--card-padding) + 25px)',
+							right: 'var(--card-padding)',
+						}}
+					>
+						{errorText}
+					</p>
+				)}
+				<Button
+					appearance={'neutral'}
+					style={{
+						position: 'fixed',
+						bottom: 'var(--card-padding)',
+						left: 'var(--card-padding)',
+					}}
+					onClick={close}
+				>
+					Cancel
+				</Button>
+				<Button
+					appearance={'accent'}
+					style={{
+						position: 'fixed',
+						bottom: 'var(--card-padding)',
+						right: 'var(--card-padding)',
+					}}
+					onClick={() => {
+						const result = processInput(content);
+						if (result.type === 'error') {
+							setErrorText(result.displayMessage);
+						} else {
+							close();
+						}
+					}}
+				>
+					{confirmText}
+				</Button>
+			</Card>
+		</Dialog>
+	);
+};

--- a/packages/site/src/components/puzzles/puzzles.tsx
+++ b/packages/site/src/components/puzzles/puzzles.tsx
@@ -24,6 +24,7 @@ import {
 	DeleteModal,
 	EditNameModal,
 	EditSheetIdModal,
+	EditUrlModal,
 } from './modals';
 import { useStore } from 'react-redux';
 import type { AppStore } from '../../store/store';
@@ -302,6 +303,14 @@ function useEditingUI(puzzlehunt: IPuzzlehunt): {
 					close={closeModal}
 				/>
 			);
+		} else if (modalArgs.modalType === 'editUrl') {
+			ui = (
+				<EditUrlModal
+					puzzleObj={puzzleObj}
+					puzzlehunt={puzzlehunt}
+					close={closeModal}
+				/>
+			);
 		} else if (modalArgs.modalType === 'solve') {
 			ui = (
 				<SolveModal
@@ -335,6 +344,7 @@ type ModalSpec =
 	| {
 			modalType: 'editName';
 	  }
+	| { modalType: 'editUrl' }
 	| {
 			modalType: 'editSheetId';
 	  }
@@ -401,6 +411,11 @@ const PuzzlePageMenu: React.FC<PuzzlePageMenu> = ({
 				onClick={(event) => openModal(event, { modalType: 'editName' })}
 			>
 				Change name
+			</MenuItem>
+			<MenuItem
+				onClick={(event) => openModal(event, { modalType: 'editUrl' })}
+			>
+				Change URL
 			</MenuItem>
 			{puzzleObj.type === 'puzzle' && (
 				<MenuItem


### PR DESCRIPTION
Implements several features which were asked for in response to mystery hunt this year.

- Workflow for making puzzles non-public documented under the about page permissions model
- Added website UI to change puzzle URL
  - Refactored existing single-target modals for better code sharing
- Added bot functionality for changing puzzle name / url / sheet id. This gives better parity with the website and should be more convenient for incremental updates.
- Add CI flow to auto-deploy bot commands to prod
- Make channel options in add_round / add_puzzle actual channel options rather than string options with post-send enforcement.