### PR TITLE
Tentative fix for token expiry

### DIFF
--- a/packages/site/src/loaders/auth.ts
+++ b/packages/site/src/loaders/auth.ts
@@ -7,6 +7,7 @@ import {
 	isLoggedInToDiscord,
 	isLoggedInToMicrosoft,
 	isReturningFromAuthServer,
+	logout,
 } from '../store/auth';
 import { store } from '../store/store';
 
@@ -19,6 +20,7 @@ export async function redirectIfAlreadyLoggedIn(): Promise<null> {
 }
 
 export async function fetchLoginInfo(): Promise<null> {
+	ensureLoginRedirect();
 	await Promise.all([fetchDiscordLoginInfo(), fetchMicrosoftUserInfo()]);
 	return null;
 }
@@ -54,4 +56,38 @@ async function fetchMicrosoftUserInfo(): Promise<null> {
 	}
 
 	return null;
+}
+
+let tokenExpiryPollInterval = 5 * 60 * 1000;
+let tokenExpiryIntervalId;
+
+// This function exists because there's not a clean way to refresh azure static webapps auth tokens.
+// See https://github.com/Azure/static-web-apps/issues/761 for more discussion.
+// In the meantime, we poll the /.auth/me endpoint to check if the static web app middleware thinks
+// the user is still logged in and use that to update the redux store state.
+export function ensureLoginRedirect(): void {
+	if (!isLoggedInToMicrosoft(store.getState())) {
+		// We were polling for auth redirect, but user has logged out.
+		if (tokenExpiryIntervalId !== undefined) {
+			clearInterval(tokenExpiryIntervalId);
+			tokenExpiryIntervalId = undefined;
+		}
+	} else if (tokenExpiryIntervalId === undefined) {
+		const poller = async () => {
+			const response = await fetch('/.auth/me');
+			const { clientPrincipal } = await response.json();
+			if (clientPrincipal) {
+				store.dispatch(clientPrincipalReceived(clientPrincipal));
+			} else {
+				store.dispatch(logout());
+			}
+		};
+		tokenExpiryIntervalId = setInterval(
+			() =>
+				poller().catch((err) =>
+					console.log('Failed to poll AAD login status:', err)
+				),
+			tokenExpiryPollInterval
+		);
+	}
 }


### PR DESCRIPTION
Long sessions were problematic during last year's mystery hunt, with the website appearing to break for people. I believe the cause of this is the 8 hour expiry on azure static web apps auth setup, after which point their session expired. None of the existing logic handled this. This change adds a 5 minute poll to the /.auth/me endpoint from auth-required endpoints, which should trigger a redirect when authentication expires.

Note: change is untested.