### PR TITLE
Add /populate_answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It uses [pnpm](https://pnpm.io/).
 ## Setup
 
 1. Install [node 18](https://nodejs.org/en/download/) or later. I recommend using [nvm](https://github.com/nvm-sh/nvm) ([windows link](https://github.com/coreybutler/nvm-windows)) to manage node versions.
-2. Install pnpm globally: `npm i -g pnpm`
+2. Enable corepack: `corepack enable`
 3. Install repo dependencies: `pnpm i`
 4. Build: `npm run build`
 

--- a/packages/bot/src/commands/index.ts
+++ b/packages/bot/src/commands/index.ts
@@ -9,3 +9,4 @@ export * from './reset-server.js';
 export * from './change-backing-fluid-file.js';
 export * from './copy-to-new-fluid-file.js';
 export * from './update-status.js';
+export * from './populate-answers.js';

--- a/packages/bot/src/commands/populate-answers.ts
+++ b/packages/bot/src/commands/populate-answers.ts
@@ -1,0 +1,214 @@
+import {
+	CacheType,
+	CategoryChannel,
+	ChannelType,
+	ChatInputCommandInteraction,
+	SlashCommandBuilder,
+} from 'discord.js';
+import { Command } from './types';
+import { PuzzlehuntContext } from '../puzzlehunt-context';
+import {
+	computeAssociatedRoundOrPuzzle,
+	descendantPuzzles,
+} from '../utils/index.js';
+import {
+	getByDataFilter,
+	updateSheet,
+	updateSheetValues,
+} from '../integrations/google.js';
+
+const ROUND_ARG = 'round';
+
+export const populateAnswers: Command = {
+	data: new SlashCommandBuilder()
+		.setName('populate_answers')
+		.addChannelOption((builder) =>
+			builder
+				.setDescription('Round to add answers from')
+				.addChannelTypes(ChannelType.GuildCategory)
+				.setName(ROUND_ARG)
+				.setRequired(true)
+		)
+		.setDescription(
+			"Adds links and answers to all puzzles from a round to this puzzle's google sheet. Useful for metas."
+		),
+	async execute(
+		{ puzzlehunt }: PuzzlehuntContext,
+		interaction: ChatInputCommandInteraction<CacheType>
+	) {
+		if (!interaction.deferred) {
+			await interaction.deferReply({ ephemeral: true });
+		}
+
+		const puzzleObj = await computeAssociatedRoundOrPuzzle(
+			interaction.channel,
+			puzzlehunt
+		);
+		if (!puzzleObj || puzzleObj.type === 'round') {
+			await interaction.editReply(
+				'This command must be run from a puzzle channel.'
+			);
+			return;
+		}
+
+		const { sheetId } = puzzleObj;
+		if (!sheetId) {
+			await interaction.editReply(
+				"Please wait for this puzzle's sheet to be created and retry."
+			);
+			return;
+		}
+
+		const roundArg = interaction.options.getChannel(
+			ROUND_ARG
+		) as CategoryChannel;
+		const roundToPopulateAnswersFrom = computeAssociatedRoundOrPuzzle(
+			roundArg,
+			puzzlehunt
+		);
+
+		if (
+			!roundToPopulateAnswersFrom ||
+			roundToPopulateAnswersFrom.type !== 'round'
+		) {
+			await interaction.editReply(
+				'Unable to find puzzle round associated with this category. Please select a different one.'
+			);
+			return;
+		}
+
+		const values: [string, string, string][] = [
+			['Title', 'Answer', 'Google sheet'],
+		];
+		for (const puzzle of descendantPuzzles(roundToPopulateAnswersFrom)) {
+			values.push([
+				`=hyperlink("${puzzle.url}", "${puzzle.name}")`,
+				puzzle.answer,
+				`=hyperlink("https://docs.google.com/spreadsheets/d/${puzzle.sheetId}","Link")`,
+			]);
+		}
+
+		const feederSheetName = `${roundToPopulateAnswersFrom.name} Feeder Answers`;
+		// This whole pattern is pretty awkward, but haven't found docs on expectations for what sheets APIs
+		// do when ranges don't exist or recommended ways to check for existence.
+		// Being a bit paranoid here with safety checks as overwriting data would be pretty annoying.
+		const spreadsheet = await getByDataFilter({
+			spreadsheetId: sheetId,
+		});
+
+		const existingFeederSheet = spreadsheet.sheets.find(
+			(sheet) => sheet.properties.title === feederSheetName
+		);
+		let feederSheetId: number;
+		if (existingFeederSheet !== undefined) {
+			const spreadsheetWithData = await getByDataFilter({
+				spreadsheetId: sheetId,
+				requestBody: {
+					dataFilters: [
+						{
+							a1Range: `${feederSheetName}!A1:C1`,
+						},
+					],
+					includeGridData: true,
+				},
+			});
+			const existingFeederSheetWithData = spreadsheetWithData.sheets.find(
+				(sheet) => sheet.properties.title === feederSheetName
+			);
+
+			const sheetData = existingFeederSheetWithData.data[0].rowData;
+			// Extra null checks here handle spreadsheet without values in A1:C1
+			const headerValues = (sheetData?.[0].values ?? []).map(
+				(value) => value?.userEnteredValue?.stringValue
+			);
+			if (
+				headerValues[0] !== 'Title' ||
+				headerValues[1] !== 'Answer' ||
+				headerValues[2] !== 'Google sheet'
+			) {
+				await interaction.editReply(
+					`This puzzle's spreadsheet already has a tab named '[${feederSheetName}](https://docs.google.com/spreadsheets/d/${sheetId}/edit?gid=${feederSheetId})' which doesn't match the bot's generated headers.` +
+						`Please re-run this command after renaming that tab to avoid having any of its data overwritten.`
+				);
+				return;
+			}
+			feederSheetId = existingFeederSheet.properties.sheetId;
+		} else {
+			const data = await updateSheet({
+				spreadsheetId: sheetId,
+				requestBody: {
+					requests: [
+						{
+							addSheet: {
+								properties: {
+									title: feederSheetName,
+								},
+							},
+						},
+					],
+				},
+			});
+
+			feederSheetId = data.replies[0].addSheet.properties.sheetId;
+
+			await updateSheet({
+				spreadsheetId: sheetId,
+				requestBody: {
+					requests: [
+						{
+							repeatCell: {
+								// Unispace font for puzzle title / answers
+								cell: {
+									userEnteredFormat: {
+										textFormat: {
+											fontFamily: 'Source Code Pro',
+										},
+									},
+								},
+								fields: '*',
+								range: {
+									startColumnIndex: 0,
+									endColumnIndex: 2,
+									startRowIndex: 1,
+									sheetId: feederSheetId,
+								},
+							},
+						},
+						{
+							// Bold headers
+							repeatCell: {
+								cell: {
+									userEnteredFormat: {
+										textFormat: {
+											bold: true,
+										},
+									},
+								},
+								fields: '*',
+								range: {
+									startColumnIndex: 0,
+									endColumnIndex: 3,
+									startRowIndex: 0,
+									endRowIndex: 1,
+									sheetId: feederSheetId,
+								},
+							},
+						},
+					],
+				},
+			});
+		}
+
+		await updateSheetValues({
+			spreadsheetId: sheetId,
+			requestBody: {
+				data: [{ range: `${feederSheetName}!A1:C`, values }],
+				valueInputOption: 'USER_ENTERED',
+			},
+		});
+
+		await interaction.editReply(
+			`Answers populated on the [${feederSheetName}](https://docs.google.com/spreadsheets/d/${sheetId}/edit?gid=${feederSheetId}) tab.`
+		);
+	},
+};

--- a/packages/bot/src/integrations/google.ts
+++ b/packages/bot/src/integrations/google.ts
@@ -1,21 +1,15 @@
 import '../register-env/index.js';
-import { google } from 'googleapis';
-
-let isInitialized = false;
+import { google, type sheets_v4 } from 'googleapis';
 
 export const createGoogleSheet = async (
 	name: string,
 	googleFolderId: string
 ) => {
-	if (!isInitialized) {
-		// Do this lazily to allow module load in environments that don't have access to the google api key (ex: command deployment)
-		const auth = new google.auth.GoogleAuth({
-			credentials: JSON.parse(process.env.GOOGLE_API_KEY),
-			scopes: ['https://www.googleapis.com/auth/drive.file'],
-		});
-		google.options({ auth });
-		isInitialized = true;
-	}
+	const auth = new google.auth.GoogleAuth({
+		credentials: JSON.parse(process.env.GOOGLE_API_KEY),
+		scopes: ['https://www.googleapis.com/auth/drive.file'],
+	});
+	google.options({ auth });
 	const drive = google.drive({ version: 'v3' });
 	const file = await drive.files.copy({
 		fileId: GOOGLE_SHEET_TEMPLATE_ID,
@@ -32,3 +26,58 @@ export const createGoogleSheet = async (
 // Since Belle Bot only gets drive.file though, the flow might be somewhat janky.
 export const GOOGLE_SHEET_TEMPLATE_ID =
 	'1IqR4EcKA7gkxvveIzPCgcbcWUozMbsQwDXbKcQaPH9U';
+
+export async function updateSheetValues(
+	params: sheets_v4.Params$Resource$Spreadsheets$Values$Batchupdate
+): Promise<void> {
+	const auth = new google.auth.GoogleAuth({
+		credentials: JSON.parse(process.env.GOOGLE_API_KEY),
+		scopes: ['https://www.googleapis.com/auth/drive.file'],
+	});
+	google.options({ auth });
+	const sheets = google.sheets({ version: 'v4' });
+	const response = await sheets.spreadsheets.values.batchUpdate(params);
+
+	if (response.status !== 200) {
+		console.log(response);
+		throw new Error(`Issue updating data: ${response.statusText}`);
+	}
+}
+
+export async function updateSheet(
+	params: sheets_v4.Params$Resource$Spreadsheets$Batchupdate
+): Promise<sheets_v4.Schema$BatchUpdateSpreadsheetResponse> {
+	const auth = new google.auth.GoogleAuth({
+		credentials: JSON.parse(process.env.GOOGLE_API_KEY),
+		scopes: ['https://www.googleapis.com/auth/drive.file'],
+	});
+	google.options({ auth });
+	const sheets = google.sheets({ version: 'v4' });
+	const response = await sheets.spreadsheets.batchUpdate(params);
+
+	if (response.status !== 200) {
+		console.log(response);
+		throw new Error(`Issue updating data: ${response.statusText}`);
+	}
+
+	return response.data;
+}
+
+export async function getByDataFilter(
+	params: sheets_v4.Params$Resource$Spreadsheets$Getbydatafilter
+): Promise<sheets_v4.Schema$Spreadsheet> {
+	const auth = new google.auth.GoogleAuth({
+		credentials: JSON.parse(process.env.GOOGLE_API_KEY),
+		scopes: ['https://www.googleapis.com/auth/drive.file'],
+	});
+	google.options({ auth });
+	const sheets = google.sheets({ version: 'v4' });
+	const response = await sheets.spreadsheets.getByDataFilter(params);
+
+	if (response.status !== 200) {
+		console.log(response);
+		throw new Error(`Issue updating data: ${response.statusText}`);
+	}
+
+	return response.data;
+}

--- a/packages/bot/src/utils/index.ts
+++ b/packages/bot/src/utils/index.ts
@@ -136,6 +136,19 @@ export function generateRoundEmbed(
 	return { embeds: [embed], components: rows };
 }
 
+export function* descendantPuzzles(round: Round): Iterable<Puzzle> {
+	for (const child of round.children) {
+		switch (child.type) {
+			case 'puzzle':
+				yield child;
+				break;
+			case 'round':
+				yield* descendantPuzzles(child);
+				break;
+		}
+	}
+}
+
 export function computeAssociatedRoundOrPuzzle(
 	channel: TextBasedChannel | CategoryChannel,
 	puzzlehunt: IPuzzlehunt


### PR DESCRIPTION
Adds some functionality which should be useful for metas.

When `/populate_answers <round channel>` is run from a puzzle channel, a tab (sheet) will be added to that puzzle's spreadsheet containing all feeder answers from puzzles which are descendants of the specified round. 