### PR TITLE
Fix website 'install on discord' button redirecting

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -20,7 +20,7 @@ jobs:
               with:
                   submodules: true
             - name: Install dependencies
-              run: npm i -g pnpm@7.27.0 && pnpm i --frozen-lockfile
+              run: corepack enable && pnpm i --frozen-lockfile
 
             - name: Run build
               run: npm run build

--- a/packages/site/src/components/redirect.tsx
+++ b/packages/site/src/components/redirect.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { Navigate, Outlet, useSearchParams } from 'react-router-dom';
 import { getPostRedirectPath, setPostRedirectPath } from '../redirect';
 
 export const RootRedirect: React.FC = () => {
@@ -11,4 +11,21 @@ export const RootRedirect: React.FC = () => {
 	}
 
 	return <Navigate to={`/home?${params}`} replace />;
+};
+
+// OAuth2 redirect URIs include these but they are not generally useful after consumption.
+// Though we consume these at the top-level in a loader, it's easiest to remove them inside a react component
+// (setting window.location.search works but triggers extra page reloads)
+const paramsToRemove = ['code', 'state', 'guild_id', 'permissions'];
+export const RemoveAuthParams: React.FC = () => {
+	const [search, setSearch] = useSearchParams();
+	React.useEffect(() => {
+		if (paramsToRemove.some((param) => search.has(param))) {
+			for (const param of paramsToRemove) {
+				search.delete(param);
+			}
+			setSearch(search);
+		}
+	}, [search]);
+	return <Outlet />;
 };

--- a/packages/site/src/loaders/auth.ts
+++ b/packages/site/src/loaders/auth.ts
@@ -34,13 +34,6 @@ async function fetchDiscordLoginInfo(): Promise<null> {
 		await store.dispatch(fetchToken());
 	}
 
-	const params = new URLSearchParams(window.location.search);
-	if (params.has('code') || params.has('state')) {
-		params.delete('code');
-		params.delete('state');
-		throw redirect(`${window.location.pathname}?${params}`);
-	}
-
 	return null;
 }
 

--- a/packages/site/src/router.tsx
+++ b/packages/site/src/router.tsx
@@ -4,7 +4,6 @@ import {
 	RouterProvider,
 	Route,
 	createRoutesFromElements,
-	useRouteError,
 } from 'react-router-dom';
 import {
 	About,
@@ -16,6 +15,7 @@ import {
 	Servers,
 	NavBar,
 	RootRedirect,
+	RemoveAuthParams,
 } from './components';
 import { fetchLoginInfo, redirectIfAlreadyLoggedIn } from './loaders';
 
@@ -28,30 +28,32 @@ export const Router: React.FC = () => {
 				createRoutesFromElements([
 					<Route path="/logout" element={<Logout />} />,
 					<Route element={<NavBar />} loader={fetchLoginInfo}>
-						<Route path="/home" element={<Home />} />,
-						<Route path="/about" element={<About />} />,
-						<Route
-							path="/login"
-							element={<Login />}
-							loader={redirectIfAlreadyLoggedIn}
-						/>
-						<Route
-							path="/servers"
-							element={
-								<LoginGate>
-									<Servers />
-								</LoginGate>
-							}
-						/>
-						<Route
-							path="/hunt/:guildId"
-							element={
-								<LoginGate>
-									<Puzzles />
-								</LoginGate>
-							}
-						/>
-						<Route path="*" element={<RootRedirect />} />,
+						<Route element={<RemoveAuthParams />}>
+							<Route path="/home" element={<Home />} />,
+							<Route path="/about" element={<About />} />,
+							<Route
+								path="/login"
+								element={<Login />}
+								loader={redirectIfAlreadyLoggedIn}
+							/>
+							<Route
+								path="/servers"
+								element={
+									<LoginGate>
+										<Servers />
+									</LoginGate>
+								}
+							/>
+							<Route
+								path="/hunt/:guildId"
+								element={
+									<LoginGate>
+										<Puzzles />
+									</LoginGate>
+								}
+							/>
+							<Route path="*" element={<RootRedirect />} />,
+						</Route>
 					</Route>,
 				])
 			),


### PR DESCRIPTION
Adjusts some kludgy logic around moving extraneous search parameters in the URL by doing so in a react component instead of the loader. This fixes a bug which caused infinite redirects when returning to belle-puzzles from discord, since throwing `redirect('/foo')` from a loader does not update search params.

Also updates the website deploy template to use corepack to install pnpm, which plausibly could fix a recent issue with installing dependencies in that pipeline.