### PR TITLE
Add pin messages permission to install link

### DIFF
--- a/packages/site/src/store/auth.ts
+++ b/packages/site/src/store/auth.ts
@@ -123,8 +123,9 @@ export function createAddBotToServerUrl(): string {
 		 * - Read Message History
 		 * - Add Reactions
 		 * - Use Slash Commands
+		 * - Pin Messages
 		 */
-		permissions: '397552987216',
+		permissions: '2252197366672464',
 		redirect_uri: window.location.origin,
 		response_type: 'code',
 		scope: ['bot', ...scopes].join(' '),


### PR DESCRIPTION
Discord split the pin message permission out in a breaking change in February, see [change log](https://docs.discord.com/developers/change-log#november-24-2025).

This updates the server install link permissions to include "pin messages", which is necessary for Belle to function (reads/edits channel messages using pins in current implementation)